### PR TITLE
feat(type) autorequire package s3ql

### DIFF
--- a/lib/puppet/type/s3ql_mount.rb
+++ b/lib/puppet/type/s3ql_mount.rb
@@ -98,4 +98,8 @@ Puppet::Type.newtype(:s3ql_mount) do
       This property is read-only.
     EOS
   end
+
+  autorequire(:package) do
+    's3ql'
+  end
 end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,8 +9,9 @@ class s3ql (
   $package_provider = undef,
 ) {
 
-  package { $package_name:
+  package { 's3ql':
     ensure   => $package_ensure,
+    name     => $package_name,
     provider => $package_provider,
   }
 }

--- a/spec/classes/s3ql_spec.rb
+++ b/spec/classes/s3ql_spec.rb
@@ -28,8 +28,9 @@ describe 's3ql' do
           it { is_expected.to compile.with_all_deps }
 
           it do
-            is_expected.to contain_package('python3-s3ql')
+            is_expected.to contain_package('s3ql')
               .with_ensure('latest')
+              .with_name('python3-s3ql')
               .with_provider('pip')
           end
         end


### PR DESCRIPTION
since everything we do in the provider depends on the s3ql_\* binaries,
we should autorequire them in the type.

This fixes #2
