### PR TITLE
allow setting --metadata-upload-interval

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -182,6 +182,11 @@ but this might be wrong for users who have no `$HOME`, for instance.
 If a `mount.s3ql` fails, we'll try to rescue by running `fsck.s3ql`. This
 flag determines whether to run `fsck.s3ql` with `--force`. Default: `false`
 
+#### s3ql_mount::upload_inverval
+
+Interval in seconds between complete metadata uploads. Set to 0 to disable.
+Default: 24h. (86400s)
+
 #### s3ql_mount::backend
 
 The backend used. This property is read-only.

--- a/lib/puppet/provider/s3ql_mount/s3ql_mount.rb
+++ b/lib/puppet/provider/s3ql_mount/s3ql_mount.rb
@@ -51,16 +51,18 @@ Puppet::Type.type(:s3ql_mount).provide(:s3ql_mount) do
   end
 
   def mount_s3ql(*arguments)
-    all_args = ['--allow-other', arguments].flatten
+    mount_args = ['--allow-other', '--metadata-upload-interval',
+                  @resource[:upload_inverval], arguments].flatten
     begin
-      commands_wrapper('mount.s3ql', all_args)
+      commands_wrapper('mount.s3ql', mount_args)
     rescue Puppet::ExecutionFailure
       fsck_args = []
       fsck_args << '--batch'
       fsck_args << '--force' if @resource[:force]
       fsck_args << @resource[:storage_url]
       commands_wrapper('fsck.s3ql', fsck_args)
-      commands_wrapper('mount.s3ql', all_args)
+      # retry
+      commands_wrapper('mount.s3ql', mount_args)
     end
   end
 

--- a/lib/puppet/provider/s3ql_mount/s3ql_mount.rb
+++ b/lib/puppet/provider/s3ql_mount/s3ql_mount.rb
@@ -58,6 +58,7 @@ Puppet::Type.type(:s3ql_mount).provide(:s3ql_mount) do
       fsck_args = []
       fsck_args << '--batch'
       fsck_args << '--force' if @resource[:force]
+      fsck_args << @resource[:storage_url]
       commands_wrapper('fsck.s3ql', fsck_args)
       commands_wrapper('mount.s3ql', all_args)
     end

--- a/lib/puppet/type/s3ql_mount.rb
+++ b/lib/puppet/type/s3ql_mount.rb
@@ -75,6 +75,15 @@ Puppet::Type.newtype(:s3ql_mount) do
     end
   end
 
+  # this one is not discoverable, hence a it is a parameter
+  newparam(:upload_interval) do
+    desc <<-EOS
+      Interval in seconds between complete metadata uploads.
+      Set to 0 to disable. Default: 24h. (86400s)
+    EOS
+    defaultto 86400
+  end
+
   newproperty(:backend_options) do
     desc 'Additional options passed to mount.s3ql when mounting this filesystem.'
   end

--- a/spec/unit/type/s3ql_mount_spec.rb
+++ b/spec/unit/type/s3ql_mount_spec.rb
@@ -26,6 +26,7 @@ describe type_class do
       :mountpoint,
       :home,
       :force,
+      :upload_interval,
     ]
   end
 


### PR DESCRIPTION
setting this lower than 24h will allow us to to lose less than a day's worth of data when we lose a machine (:

:fire: :computer: :fire:

D:
