### PR TITLE
new flag: allow other

### DIFF
--- a/lib/puppet/provider/s3ql_mount/s3ql_mount.rb
+++ b/lib/puppet/provider/s3ql_mount/s3ql_mount.rb
@@ -89,11 +89,23 @@ Puppet::Type.type(:s3ql_mount).provide(:s3ql_mount) do
     mounts.map do |mnt|
       storage_url, _, mountpoint, _, _, options = mnt.split
 
-      owner = options.sub(%r{.*user(_id)?=([^,)]+).*}, '\2') if options =~ %r{user(_id)?}
+      opts_hsh = options.split(',').map { |o|
+        k = o
+        v = true
+        if o.include?('=')
+          k, v = split('=')
+        end
+        [k, v]
+      }.to_h
+
+      owner = opts_hsh['user']
+      owner ||= opts_hsh['user_id']
       owner ||= 0
-      group = options.sub(%r{.*group(_id)?=([^,)]).*}, '\2') if options =~ %r{group(_id)?}
+      group = opts_hsh['group']
+      group ||= opts_hsh['group_id']
       group ||= 0
-      # XXX: is allow_others in options?
+      allow_other = opts_hsh['allow_other']
+      allow_other ||= false
 
       # and initialize @property_hash
       new(name: mountpoint,
@@ -102,7 +114,8 @@ Puppet::Type.type(:s3ql_mount).provide(:s3ql_mount) do
           storage_url: storage_url,
           owner: owner,
           group: group,
-          backend: storage_url.split(':')[0])
+          backend: storage_url.split(':')[0],
+          allow_other: allow_other)
     end
   end
 

--- a/lib/puppet/provider/s3ql_mount/s3ql_mount.rb
+++ b/lib/puppet/provider/s3ql_mount/s3ql_mount.rb
@@ -50,8 +50,11 @@ Puppet::Type.type(:s3ql_mount).provide(:s3ql_mount) do
     Puppet::Util::Execution.execute([command, all_args], opts)
   end
 
+  # TODO: This *arguments paramether is kinda pointless
   def mount_s3ql(*arguments)
-    mount_args = ['--allow-other', '--metadata-upload-interval',
+    allow_other = ''
+    allow_other = '--allow-other' if @resource[:allow_other]
+    mount_args = [allow_other, '--metadata-upload-interval',
                   @resource[:upload_inverval], arguments].flatten
     begin
       commands_wrapper('mount.s3ql', mount_args)
@@ -90,6 +93,7 @@ Puppet::Type.type(:s3ql_mount).provide(:s3ql_mount) do
       owner ||= 0
       group = options.sub(%r{.*group(_id)?=([^,)]).*}, '\2') if options =~ %r{group(_id)?}
       group ||= 0
+      # XXX: is allow_others in options?
 
       # and initialize @property_hash
       new(name: mountpoint,

--- a/lib/puppet/type/s3ql_mount.rb
+++ b/lib/puppet/type/s3ql_mount.rb
@@ -114,7 +114,7 @@ Puppet::Type.newtype(:s3ql_mount) do
     end
   end
 
-  newparam(:allow_other) do
+  newproperty(:allow_other) do
     desc <<-EOS
       Whether to allow "other" to access this mountpoint
 

--- a/lib/puppet/type/s3ql_mount.rb
+++ b/lib/puppet/type/s3ql_mount.rb
@@ -114,6 +114,19 @@ Puppet::Type.newtype(:s3ql_mount) do
     end
   end
 
+  newparam(:allow_other) do
+    desc <<-EOS
+      Whether to allow "other" to access this mountpoint
+
+      The default is `false`. To allow it, also make sure to set `allow_other` in `s3ql`.
+    EOS
+    defaultto :false
+    munge do |val|
+      :false if [false, 'false', :false].include? val
+      :true  if [true, 'true', :true].include? val
+    end
+  end
+
   newproperty(:backend) do
     desc <<-EOS
       The backend used.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,11 +7,20 @@ class s3ql (
   $package_name     = 's3ql',
   $package_ensure   = 'present',
   $package_provider = undef,
+  $allow_other = false,
 ) {
 
   package { 's3ql':
     ensure   => $package_ensure,
     name     => $package_name,
     provider => $package_provider,
+  }
+
+  if $allow_other {
+    file_line { "user_allow_other ${allow_other}":
+      path  => '/etc/fuse.conf',
+      line  => 'user_allow_other',
+      match => '^#user_allow_other'
+    }
   }
 }

--- a/spec/unit/provider/s3ql_mount/s3ql_mount.rb
+++ b/spec/unit/provider/s3ql_mount/s3ql_mount.rb
@@ -11,6 +11,7 @@ describe provider_class do
         storage_url: 'gs://bucket/prefix',
         owner: 'examplewww',
         group: 'examplewww',
+        allow_other: true,
       )
     end
 

--- a/spec/unit/type/s3ql_mount_spec.rb
+++ b/spec/unit/type/s3ql_mount_spec.rb
@@ -19,6 +19,7 @@ describe type_class do
       :owner,
       :group,
       :backend,
+      :allow_other,
     ]
   end
   let :parameters do


### PR DESCRIPTION
This pr adds a flag `allow_other` as per #8 
We add it to both, the `s3ql` init class, and to `s3ql_mount`.